### PR TITLE
feat: add gog CLI for Google Workspace integration

### DIFF
--- a/clawdbot_gateway/Dockerfile
+++ b/clawdbot_gateway/Dockerfile
@@ -16,6 +16,14 @@ RUN apt-get update \
 
 RUN npm install -g pnpm@9.12.3
 
+# Install gog CLI (Google Workspace: Gmail, Calendar, Drive, Contacts, Sheets, Docs)
+ARG GOG_VERSION=0.4.2
+ARG TARGETARCH
+RUN ARCH=$(echo ${TARGETARCH:-$(uname -m)} | sed 's/aarch64/arm64/;s/x86_64/amd64/') \
+  && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v${GOG_VERSION}/gogcli_${GOG_VERSION}_linux_${ARCH}.tar.gz" \
+     | tar xz -C /usr/local/bin gog \
+  && chmod +x /usr/local/bin/gog
+
 WORKDIR /opt/clawdbot
 
 COPY run.sh /run.sh


### PR DESCRIPTION
Adds gogcli (Gmail, Calendar, Drive, Contacts, Sheets, Docs)\n\n- Architecture-aware installation (arm64/amd64)\n- Version pinned to 0.4.2\n\nSee: https://gogcli.sh