### PR TITLE
chore(docker): refresh base toolchain

### DIFF
--- a/clawdbot_gateway/Dockerfile
+++ b/clawdbot_gateway/Dockerfile
@@ -1,6 +1,11 @@
-FROM node:22-bookworm-slim
+FROM node:24-bookworm-slim
 
+# Use bash with pipefail so curl|tar failures stop the build.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Pull latest Debian security updates, then clean apt caches.
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
@@ -14,12 +19,13 @@ RUN apt-get update \
     make \
     g++ \
     openssh-server \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 ENV PNPM_HOME=/pnpm
 ENV PATH="${PNPM_HOME}:${PATH}"
 
-RUN npm install -g pnpm@9.12.3 \
+RUN npm install -g pnpm \
   && mkdir -p /pnpm \
   && pnpm config set global-bin-dir /pnpm \
   && pnpm add -g clawdhub
@@ -27,7 +33,7 @@ RUN npm install -g pnpm@9.12.3 \
 RUN pip3 install --no-cache-dir --break-system-packages homeassistant-cli
 
 # Install gog CLI (Google Workspace: Gmail, Calendar, Drive, Contacts, Sheets, Docs)
-ARG GOG_VERSION=0.4.2
+ARG GOG_VERSION=0.6.1
 ARG TARGETARCH
 RUN ARCH=$(echo ${TARGETARCH:-$(uname -m)} | sed 's/aarch64/arm64/;s/x86_64/amd64/') \
   && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v${GOG_VERSION}/gogcli_${GOG_VERSION}_linux_${ARCH}.tar.gz" \


### PR DESCRIPTION
Move the add-on image to the Node 24 LTS base and update gogcli to its current release while adding notes for the security and build-hardening choices in the Dockerfile. This keeps the image aligned with upstream support timelines and makes curl|tar failures explicit during image builds.