### PR TITLE
Install Bun runtime in add-on image

### DIFF
--- a/clawdbot_gateway/CHANGELOG.md
+++ b/clawdbot_gateway/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.12
+- Docker: install Bun runtime.
+
 ## 0.2.11
 - Docker: install GitHub CLI.
 - Storage: persist root home directories under /config/clawdbot.

--- a/clawdbot_gateway/Dockerfile
+++ b/clawdbot_gateway/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
     ripgrep \
     curl \
     nano \
+    unzip \
     python3 \
     python3-pip \
     make \
@@ -38,8 +39,11 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
   && apt-get install -y gh \
   && rm -rf /var/lib/apt/lists/*
 
+ENV BUN_INSTALL=/usr/local/bun
 ENV PNPM_HOME=/pnpm
-ENV PATH="${PNPM_HOME}:${PATH}"
+ENV PATH="${BUN_INSTALL}/bin:${PNPM_HOME}:${PATH}"
+
+RUN curl -fsSL https://bun.sh/install | bash
 
 RUN npm install -g pnpm \
   && mkdir -p /pnpm \

--- a/clawdbot_gateway/config.json
+++ b/clawdbot_gateway/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Clawdbot Gateway",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "slug": "clawdbot_gateway",
   "description": "Clawdbot Gateway (SSH-tunneled, HA add-on)",
   "url": "https://github.com/ngutman/clawdbot-ha-addon",


### PR DESCRIPTION
## Summary
- install Bun in the add-on image
- expose Bun on PATH for build/runtime use
- bump add-on version and changelog

## Testing
- docker build -t clawdbot_gateway:test .
- docker run --rm clawdbot_gateway:test bun --version