### PR TITLE
fix(gateway): install dev deps for build

### DIFF
--- a/clawdbot_gateway/CHANGELOG.md
+++ b/clawdbot_gateway/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.15
+- Fix: install dev dependencies so gateway builds include tsc. (#9)
+
 ## 0.2.14
 - Add pretty log formatting options for the add-on Log tab.
 

--- a/clawdbot_gateway/config.json
+++ b/clawdbot_gateway/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Clawdbot Gateway",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "slug": "clawdbot_gateway",
   "description": "Clawdbot Gateway (SSH-tunneled, HA add-on)",
   "url": "https://github.com/ngutman/clawdbot-ha-addon",

--- a/clawdbot_gateway/run.sh
+++ b/clawdbot_gateway/run.sh
@@ -168,7 +168,7 @@ cd "${REPO_DIR}"
 
 log "installing dependencies"
 pnpm config set confirmModulesPurge false >/dev/null 2>&1 || true
-pnpm install --no-frozen-lockfile --prefer-frozen-lockfile
+pnpm install --no-frozen-lockfile --prefer-frozen-lockfile --prod=false
 log "building gateway"
 pnpm build
 if [ ! -d "${REPO_DIR}/ui/node_modules" ]; then


### PR DESCRIPTION
## Summary\n- install dev dependencies during add-on build to ensure tsc is available\n- bump add-on version to 0.2.15 and update changelog\n\n## Testing\n- docker build ./clawdbot_gateway\n- docker run with minimal options (gateway booted)\n\nCloses #9