### PR TITLE
fix: prevent infinite restart loop when openclaw exits as PID 1

### DIFF
--- a/clawdbot_gateway/run.sh
+++ b/clawdbot_gateway/run.sh
@@ -330,4 +330,7 @@ if [ "${VERBOSE}" = "true" ]; then
   ARGS+=(--verbose)
 fi
 
+# Disable respawn: container binary cannot self-update, respawn just kills PID 1
+export OPENCLAW_NO_RESPAWN=1
+
 exec openclaw "${ARGS[@]}"


### PR DESCRIPTION
## Problem

When running in package mode, `run.sh` ends with `exec openclaw "${ARGS[@]}"`, making openclaw PID 1. When openclaw triggers a full-process respawn (update detected, config change requiring restart), it calls `process.exit()` — which kills the container. HA immediately restarts it, openclaw exits again, and the cycle repeats.

Confirmed on HAOS Raspberry Pi 4B, add-on v0.2.18, openclaw v2026.3.2.

## Solution

Set `OPENCLAW_NO_RESPAWN=1` before `exec openclaw` to disable the full-process respawn path. The binary is baked into the Docker image and cannot self-update at runtime, so respawn only causes restart loops.

This keeps `exec` for clean PID 1 behavior and lets real crashes surface correctly in HA (container exits → add-on shows as stopped).

## Changes

- Added `export OPENCLAW_NO_RESPAWN=1` in `run.sh` before `exec openclaw`